### PR TITLE
Multi-resolution improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+tmp.py
+.DS_Store
 **/__pycache__/
 *.so
 pystare.egg-info/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-__pycache__/*
+**/__pycache__/
 *.so
 pystare.egg-info/*
 build/*

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,7 +1,7 @@
 
 # PySTARE Notes
 
-## 2020-03-19 0.5.6
+## 2020-03-19 0.6.0
 
 srange and intersect were often not returning multi-resolution
 results. Added a set_values_multi_resolution method to srange and

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,16 @@
 
 # PySTARE Notes
 
+## 2020-03-19 0.5.6
+
+srange and intersect were often not returning multi-resolution
+results. Added a set_values_multi_resolution method to srange and
+added a multi_resolution flag to StareResult. Setting values
+multi_resolution to true turns on expandIntervalsMultiRes, coalescing
+quadruplets of trixels whenever it can. If values multi_resolution is
+false then we should get expansions based on the resolution encoded
+with the interval.
+
 ## 2020-09-01 0.5.5
 
 intersects now provides several methods for matching two arrays of

--- a/PySTARE.cpp
+++ b/PySTARE.cpp
@@ -166,10 +166,10 @@ void from_intervals(int64_t* intervals, int len, int64_t* indices_starts, int64_
 //	}
 }
 
-StareResult _expand_intervals(int64_t* indices, int len, int resolution) {
+StareResult _expand_intervals(int64_t* indices, int len, int resolution, bool multi_resolution) {
   STARE_SpatialIntervals si(indices,indices+len);
   StareResult result;
-  result.add_indexValues(expandIntervals(si,resolution));
+  result.add_indexValues(expandIntervalsMultiRes(si,resolution, multi_resolution));
   return result;
 }
 
@@ -344,7 +344,8 @@ void _intersect_multiresolution(int64_t* indices1, int len1, int64_t* indices2, 
 	// cout << 300 << endl << flush;
 	STARE_SpatialIntervals result_intervals = ri->toSpatialIntervals();
 	delete ri;
-	STARE_ArrayIndexSpatialValues result = expandIntervals(result_intervals);
+	// STARE_ArrayIndexSpatialValues result = expandIntervals(result_intervals);
+	STARE_ArrayIndexSpatialValues result = expandIntervalsMultiRes(result_intervals,-1,true);
 	// cout << 400 << endl << flush;
 	leni = result.size();
 	// cout << 500 << " result size " << result.size() << endl << flush;
@@ -445,6 +446,9 @@ void _cmp_temporal(int64_t* indices1, int len1, int64_t* indices2, int len2, int
 	}
 }
 
+
+////////////////////////////////////////////////////////////////////////////////
+//
 StareResult::~StareResult() {}
 int  StareResult::get_size() {
   switch( sCase ) {
@@ -452,6 +456,9 @@ int  StareResult::get_size() {
   case SpatialIntervals        : return get_size_as_intervals();
   }
   return -1; // Maybe throw something instead.
+}
+void StareResult::set_values_multi_resolution(bool multi_resolution) {
+  values_multi_resolution = multi_resolution;  
 }
 int  StareResult::get_size_as_values() {
   if( sCase == SpatialIntervals ) {
@@ -507,11 +514,17 @@ void StareResult::convert() {
     }
     break;
   case SpatialIntervals :
-    sisvs = expandIntervals(sis);
+    sisvs = expandIntervalsMultiRes(sis,-1,values_multi_resolution);
     break;
   }
   converted = true;
 }
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
 
 srange::srange() {}
 
@@ -541,17 +554,18 @@ void srange::acontains(int64_t* indices1, int len1, int64_t* range_indices, int 
     }
   }
 }
-
 void srange::extract_intervals() {
   sis = range.toSpatialIntervals();
   intervals_extracted = true;
 }
-
+void srange::set_values_multi_resolution(bool multi_resolution) {
+  values_multi_resolution = multi_resolution;
+}
 void srange::extract_values() {
   if( !intervals_extracted ) {
     extract_intervals();
   }
-  sivs = expandIntervals(sis);
+  sivs = expandIntervalsMultiRes(sis,-1,values_multi_resolution);
   values_extracted = true;
 }
 
@@ -567,33 +581,28 @@ void srange::copy_intervals(int64_t* indices, int len) {
     indices[i] = sis[i];
   }
 }
-
 int srange::get_size_as_values() {
   if( !values_extracted ) {
     extract_values();
   }
   return sivs.size();
 }
-
 void srange::copy_values(int64_t* indices, int len) {
   int n_sivs = get_size_as_values();
   for(  int i=0; i < min(len,n_sivs); ++i ) {
     indices[i] = sivs[i];
   }
 }
-
 void srange::reset_extraction() {
   intervals_extracted = false;
   values_extracted = false;
   sis.clear();
   sivs.clear();
 }
-
 void srange::reset() {
   reset_extraction();
   range.reset();
 }
-
 void srange::purge() {
   reset_extraction();
   range.purge();

--- a/PySTARE.cpp
+++ b/PySTARE.cpp
@@ -212,7 +212,8 @@ StareResult _to_box_cover_from_latlon(double* lat, int len_lat, double* lon, int
 void _to_compressed_range(int64_t* indices, int len, int64_t* range_indices, int len_ri) {
 	STARE_SpatialIntervals si(indices, indices+len);
 	SpatialRange r(si);
-	STARE_SpatialIntervals result = r.toSpatialIntervals();
+	r.compress();
+	STARE_SpatialIntervals result = r.toSpatialIntervals(); 
 	for(int i=0; i<result.size(); ++i) {
 		range_indices[i] = result[i];
 	}

--- a/PySTARE.h
+++ b/PySTARE.h
@@ -71,6 +71,8 @@ class StareResult {
   void add_indexValues(STARE_ArrayIndexSpatialValues sisvs) { this->sisvs = sisvs; this->sCase = ArrayIndexSpatialValues; }
   virtual ~StareResult();
   int                           get_size();
+  bool                          values_multi_resolution = true;
+  void                          set_values_multi_resolution(bool multi_resolution);
   int                           get_size_as_values();
   int                           get_size_as_intervals();
   void                          copy             (int64_t* indices, int len);
@@ -90,7 +92,7 @@ StareResult _to_circular_cover(double lat, double lon, double radius, int resolu
 StareResult _to_nonconvex_hull_range_from_latlon(double* lat, int len_lat, double* lon, int len_lon, int resolution);
 
 // void _expand_intervals(int64_t* indices, int len, int resolution, int64_t* range_indices, int len_ri, int64_t* result_size, int len_rs);
-StareResult _expand_intervals(int64_t* indices, int len, int resolution);
+StareResult _expand_intervals(int64_t* indices, int len, int resolution, bool multi_resolution);
 
 // void _to_box_cover_from_latlon(double* lat, int len_lat, double* lon, int len_lon, int resolution, int64_t* range_indices, int len_ri, int64_t* result_size, int len_rs);
 StareResult _to_box_cover_from_latlon(double* lat, int len_lat, double* lon, int len_lon, int resolution);
@@ -125,20 +127,23 @@ public:
   void copy_intervals(int64_t* indices, int len);
 
   bool values_extracted = false;
-  void extract_values();
-  int get_size_as_values();
+  bool values_multi_resolution = true;
+  void set_values_multi_resolution(bool multi_resolution);
+  void extract_values(); // defaults to !multi_res
+  int get_size_as_values(); // defaults to !multi_res
   void copy_values(int64_t* indices, int len);
 
   void reset_extraction();
   void reset();
   void purge();
+  void compress() { range.compress(); }
 
   SpatialRange range;
   STARE_SpatialIntervals sis;
   STARE_ArrayIndexSpatialValues    sivs;
 
   void add_intersect(const srange& one, const srange& other,bool compress) {
-    // cout << " compress " << compress << endl << flush;
+    cout << " compress " << compress << endl << flush;
     
 //   HstmRange *range1 = new HstmRange(range.range->range->RangeFromIntersection(other.range.range->range,compress)); // NOTE mlr Probably about the safest way to inst. SpatialRange.
 // // #define DIAG

--- a/PySTARE.h
+++ b/PySTARE.h
@@ -143,7 +143,7 @@ public:
   STARE_ArrayIndexSpatialValues    sivs;
 
   void add_intersect(const srange& one, const srange& other,bool compress) {
-    cout << " compress " << compress << endl << flush;
+    // cout << " compress " << compress << endl << flush;
     
 //   HstmRange *range1 = new HstmRange(range.range->range->RangeFromIntersection(other.range.range->range,compress)); // NOTE mlr Probably about the safest way to inst. SpatialRange.
 // // #define DIAG

--- a/PySTARE.i
+++ b/PySTARE.i
@@ -482,8 +482,8 @@ def to_compressed_range(indices):
     range_indices = range_indices[:endarg]
     return range_indices
     
-def expand_intervals(intervals, resolution):
-    result = _expand_intervals(intervals,resolution)
+def expand_intervals(intervals, resolution, multi_resolution=False):
+    result = _expand_intervals(intervals,resolution,multi_resolution)
     expanded_intervals = numpy.zeros([result.get_size_as_intervals()],dtype=numpy.int64)
     result.copy_as_values(expanded_intervals)
     return expanded_intervals

--- a/examples/test_intersect_single_res.py
+++ b/examples/test_intersect_single_res.py
@@ -74,10 +74,10 @@ def test_intersect_single_res(proj,transf):
      plot1(None,None,lonsT,latsT,triangT,c0='r',c1='b',transf=transf,ax=ax)
      # plt.show()
 
-     print('   len(False),len(True),delta: ',len(intersectedFalse),len(intersectedTrue),len(intersectedTrue)-len(intersectedFalse))
-     print('un len(False),len(True),delta: ',len(numpy.unique(intersectedFalse)),len(numpy.unique(intersectedTrue)),len(numpy.unique(intersectedTrue))-len(numpy.unique(intersectedFalse)))
-     print('compressed==True, first total, then w/o double counting: ',(7*16)+(17*4),(7*16)+(17*4)-(7+17))
-     print('count 0:    ',sum([1,34,34,4*6,24,22,9]))
+     ## ok ## print('   len(False),len(True),delta: ',len(intersectedFalse),len(intersectedTrue),len(intersectedTrue)-len(intersectedFalse))
+     ## ok ## print('un len(False),len(True),delta: ',len(numpy.unique(intersectedFalse)),len(numpy.unique(intersectedTrue)),len(numpy.unique(intersectedTrue))-len(numpy.unique(intersectedFalse)))
+     ## ok ## print('compressed==True, first total, then w/o double counting: ',(7*16)+(17*4),(7*16)+(17*4)-(7+17))
+     # print('count 0:    ',sum([1,34,34,4*6,24,22,9]))
      
      if True:
         r0 = pystare.srange()
@@ -104,7 +104,7 @@ def test_intersect_single_res(proj,transf):
         r01.add_intersect(r0,r1,True)
         # n01 = r01.get_size_as_values()
         # n01 = r01.get_size_as_values_multi_resolution(False)
-        n01 = r01.get_size_as_values_multi_resolution(True)
+        n01 = r01.get_size_as_values()
         #? self.assertEqual(172, n01)
         # self.assertEqual(82, n01)
         print('r01 n01: ',n01)
@@ -129,10 +129,10 @@ def test_intersect_single_res(proj,transf):
         lonsRT_,latsRT_,intmatRT_ = pystare.triangulate_indices(intersected[51:55])
         triangRT_ = tri.Triangulation(lonsRT_,latsRT_,intmatRT_)
 
-        k = 51
-        for j in intersected[51:55]:
-            print(k,' siv: 0x%016x'%intersected[k])
-            k += 1
+        # k = 51
+        # for j in intersected[51:55]:
+        #     print(k,' siv: 0x%016x'%intersected[k])
+        #     k += 1
 
         plot1(None,None,lonsRT_,latsRT_,triangRT_,c0='g',c1='g',transf=transf,ax=ax)
         

--- a/examples/test_intersect_single_res.py
+++ b/examples/test_intersect_single_res.py
@@ -35,7 +35,8 @@ def test_intersect_single_res(proj,transf):
      lons1,lats1,intmat1 = pystare.triangulate_indices(hull1)
      triang1 = tri.Triangulation(lons1,lats1,intmat1)
 
-     fig, axs = plt.subplots(3,subplot_kw={'projection':proj,'transform':transf})
+     #+ fig, axs = plt.subplots(3,subplot_kw={'projection':proj,'transform':transf})
+     fig, axs = plt.subplots(4,subplot_kw={'projection':proj,'transform':transf})
      # plt.figure()
      # plt.subplot(projection=proj,transform=transf)
      ax=axs[0]
@@ -71,12 +72,74 @@ def test_intersect_single_res(proj,transf):
      lonsT,latsT,intmatT = pystare.triangulate_indices(intersectedTrue)
      triangT = tri.Triangulation(lonsT,latsT,intmatT)
      plot1(None,None,lonsT,latsT,triangT,c0='r',c1='b',transf=transf,ax=ax)
-     plt.show()
+     # plt.show()
 
-     # print('   len(False),len(True),delta: ',len(intersectedFalse),len(intersectedTrue),len(intersectedTrue)-len(intersectedFalse))
-     # print('un len(False),len(True),delta: ',len(numpy.unique(intersectedFalse)),len(numpy.unique(intersectedTrue)),len(numpy.unique(intersectedTrue))-len(numpy.unique(intersectedFalse)))
-     # print('compressed==True, first total, then w/o double counting: ',(7*16)+(17*4),(7*16)+(17*4)-(7+17))
-     # print('count 0:    ',sum([1,34,34,4*6,24,22,9]))
+     print('   len(False),len(True),delta: ',len(intersectedFalse),len(intersectedTrue),len(intersectedTrue)-len(intersectedFalse))
+     print('un len(False),len(True),delta: ',len(numpy.unique(intersectedFalse)),len(numpy.unique(intersectedTrue)),len(numpy.unique(intersectedTrue))-len(numpy.unique(intersectedFalse)))
+     print('compressed==True, first total, then w/o double counting: ',(7*16)+(17*4),(7*16)+(17*4)-(7+17))
+     print('count 0:    ',sum([1,34,34,4*6,24,22,9]))
+     
+     if True:
+        r0 = pystare.srange()
+        r0.add_intervals(hull0)
+
+        r1 = pystare.srange()
+        r1.add_intervals(hull1)
+
+        r01 = pystare.srange()
+        r01.add_intersect(r0,r1,False)
+        n01 = r01.get_size_as_values()
+
+        # self.assertEqual(328, n01)
+        intersected = numpy.zeros([n01],dtype=numpy.int64)
+        r01.copy_values(intersected)
+        # See examples/test_intersect_single_res.py
+        # self.assertEqual(328, len(intersected))
+
+        r01.purge()
+        n01 = r01.get_size_as_values()
+        # self.assertEqual(0, n01)
+
+        r01.reset()
+        r01.add_intersect(r0,r1,True)
+        # n01 = r01.get_size_as_values()
+        # n01 = r01.get_size_as_values_multi_resolution(False)
+        n01 = r01.get_size_as_values_multi_resolution(True)
+        #? self.assertEqual(172, n01)
+        # self.assertEqual(82, n01)
+        print('r01 n01: ',n01)
+        
+        intersected = numpy.zeros([n01],dtype=numpy.int64)
+        r01.copy_values(intersected)
+
+        ###??? Would intervals be different?
+
+        lonsRT,latsRT,intmatRT = pystare.triangulate_indices(intersected)
+        triangRT = tri.Triangulation(lonsRT,latsRT,intmatRT)
+
+        # fig, axs = plt.subplots(3,subplot_kw={'projection':proj,'transform':transf})
+         
+        # plt.figure()
+        # plt.subplot(projection=proj,transform=transf)
+        ax=axs[3]
+        # ax.set_global()
+        ax.coastlines()
+        # plot1(None,None,lonsRT,latsRT,triangRT,c0='r',c1='b',transf=transf,ax=ax)
+
+        lonsRT_,latsRT_,intmatRT_ = pystare.triangulate_indices(intersected[51:55])
+        triangRT_ = tri.Triangulation(lonsRT_,latsRT_,intmatRT_)
+
+        k = 51
+        for j in intersected[51:55]:
+            print(k,' siv: 0x%016x'%intersected[k])
+            k += 1
+
+        plot1(None,None,lonsRT_,latsRT_,triangRT_,c0='g',c1='g',transf=transf,ax=ax)
+        
+        print('len(intersected): ',len(intersected))
+        
+     plt.show()
+        
 
 def main():
     print('test_intersect_single_res.py visualization')

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ data_files = []
 
 setup(
     name='pystare',
-    version='0.5.5',
+    version='0.6.0',
     description="",
     cmdclass={'build_py': build_py},
     long_description=LONG_DESCRIPTION,         

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     version='0.6.0',
     description="",
     cmdclass={'build_py': build_py},
-    long_description=LONG_DESCRIPTION,         
+    long_description=LONG_DESCRIPTION,
     py_modules = ['pystare'],
     ext_modules=[pystare],    
     python_requires=">=3.5",

--- a/tests/test_intersections.py
+++ b/tests/test_intersections.py
@@ -5,7 +5,56 @@ import unittest
 lat = numpy.array([30,45,60], dtype=numpy.double)
 lon = numpy.array([45,60,10], dtype=numpy.double)
 
+def shiftarg_lon(lon):
+    "If lon is outside +/-180, then correct back."
+    if(lon>180):
+        return ((lon + 180.0) % 360.0)-180.0
+    else:
+        return lon
+
+def triangulate(i0,i1,i2):
+    "Prepare data structures for tri.Triangulate."
+    print('triangulating...')
+    # i0,i1,i2,ic = ps.to_vertices(indices)
+    i0lat,i0lon = ps.to_latlon(i0)
+    i1lat,i1lon = ps.to_latlon(i1)
+    i2lat,i2lon = ps.to_latlon(i2)
+    lats    = np.zeros([3*len(i0lat)],dtype=np.double)
+    lons    = np.zeros([3*len(i0lat)],dtype=np.double)
+    intmat  = []
+    k=0
+    for i in range(len(i0)):
+        lats[k]   = i0lat[i]
+        lons[k]   = i0lon[i]
+        lats[k+1] = i1lat[i]
+        lons[k+1] = i1lon[i]
+        lats[k+2] = i2lat[i]
+        lons[k+2] = i2lon[i]
+        intmat.append([k,k+1,k+2])
+        k=k+3
+    for i in range(len(lons)):
+        lons[i] = shiftarg_lon(lons[i])
+        print('triangulating done.')      
+    return lons,lats,intmat
+
+def triangulate1(lats,lons):
+    "Prepare data for tri.Triangulate."
+    print('triangulating1...')
+    intmat=[]
+    npts=int(len(lats)/3)
+    k=0
+    for i in range(npts):
+        intmat.append([k,k+1,k+2])
+        k=k+3
+    for i in range(len(lons)):
+        lons[i] = shiftarg_lon(lons[i])
+    print('triangulating1 done.')      
+    return lons,lats,intmat
+
+
+
 class MainTest(unittest.TestCase):
+    
     
     def test__intersect(self):        
         indices = pystare.from_latlon(lat, lon, 12)
@@ -56,7 +105,9 @@ class MainTest(unittest.TestCase):
 
         # See examples/test_intersect_single_res.py
         self.assertEqual(328, len(intersectedFalse))
-        self.assertEqual(172, len(intersectedTrue))
+        # self.assertEqual(172, len(intersectedTrue))
+        # self.assertEqual(82, len(intersectedTrue))
+        self.assertEqual(79, len(intersectedTrue))
         
     def test_intersect_repetition(self):
         a = [4114022797720682508, 4505997421712506892, 4505997834029367308, 4505997868389105676, 4505998418144919564]
@@ -71,11 +122,13 @@ class MainTest(unittest.TestCase):
         lat0 = numpy.array([ 10, 5, 60,70], dtype=numpy.double)
         lon0 = numpy.array([-30,-20,60,10], dtype=numpy.double)
         hull0 = pystare.to_hull_range_from_latlon(lat0, lon0, resolution0)
+        print("len hull0: ",len(hull0))
                                               
         resolution1 = 6
         lat1 = numpy.array([10,  20, 30, 20 ], dtype=numpy.double)
         lon1 = numpy.array([-60, 60, 60, -60], dtype=numpy.double)
         hull1 = pystare.to_hull_range_from_latlon(lat1, lon1, resolution1)
+        print("len hull1: ",len(hull1))
 
         r0 = pystare.srange()
         r0.add_intervals(hull0)
@@ -84,9 +137,15 @@ class MainTest(unittest.TestCase):
         r1.add_intervals(hull1)
 
         r01 = pystare.srange()
+        print("0800")
+        
         r01.add_intersect(r0,r1,False)
+        r01.set_values_multi_resolution(False)
+        print("0900")
+        
         n01 = r01.get_size_as_values()
 
+        print("1000")
         self.assertEqual(328, n01)
         intersected = numpy.zeros([n01],dtype=numpy.int64)
         r01.copy_values(intersected)
@@ -99,13 +158,23 @@ class MainTest(unittest.TestCase):
 
         r01.reset()
         r01.add_intersect(r0,r1,True)
+        r01.set_values_multi_resolution(True) # expand multi res
+        # ?? Do we need a compress here?
         n01 = r01.get_size_as_values()
-        self.assertEqual(172, n01)
+        # self.assertEqual(172, n01)
+        # self.assertEqual(82, n01) 
+        self.assertEqual(79, n01) # with expandIntervalMultiRes fix
         
-        intersected = numpy.zeros([n01],dtype=numpy.int64)
+        intersected  = numpy.zeros([n01],dtype=numpy.int64)
+        intersected0 = numpy.zeros([n01],dtype=numpy.int64)
+        # print('\nn01: ',n01)
+        
         r01.copy_values(intersected)
+        r01.copy_values(intersected0)
         # See examples/test_intersect_single_res.py
-        self.assertEqual(172, len(intersected))
+        # self.assertEqual(172, len(intersected))
+        # self.assertEqual(82, len(intersected))
+        self.assertEqual(79, n01) # with expandIntervalMultiRes fix        
 
         iv = intersected[3]
         self.assertEqual(True,r01.contains(int(iv)))
@@ -113,12 +182,17 @@ class MainTest(unittest.TestCase):
         iv_max_plus = 4584664420663164934 + 100000000000000000
         self.assertEqual(False,r01.contains(int(iv_max_plus)))
 
-        for i in range(int(len(intersected)/2)):
-            intersected[int(2*i)] = int(4584664420663164934 + ( 100000000000000000 + 1000000 * i ))
+        for i in range(int(len(intersected))):
+            if i % 2 == 0:            
+                intersected[int(i)] = int(4584664420663164934 + ( 100000000000000000 + 1000000 * i ))
         intersected1 = numpy.zeros(intersected.shape,dtype=numpy.int64)
-        r0.acontains(intersected,intersected1,-1)
+        # test+
+        r0.compress()
+        # test-
+        r0.acontains(intersected,intersected1,-1) # An element in r01 should be in r0, yes?
         for i in range(len(intersected)):
-            # print(i,'i',intersected[i],intersected1[i])
+            # print(i,'i',hex(intersected[i]),hex(intersected1[i]))
+            print('%3d = i, %016x, %016x, %016x'%(i,intersected[i],intersected1[i],intersected0[i]))
             if i % 2 == 0:
                 self.assertEqual(-1,intersected1[i])
             else:

--- a/tests/test_intersections.py
+++ b/tests/test_intersections.py
@@ -14,7 +14,7 @@ def shiftarg_lon(lon):
 
 def triangulate(i0,i1,i2):
     "Prepare data structures for tri.Triangulate."
-    print('triangulating...')
+    # print('triangulating...')
     # i0,i1,i2,ic = ps.to_vertices(indices)
     i0lat,i0lon = ps.to_latlon(i0)
     i1lat,i1lon = ps.to_latlon(i1)
@@ -34,12 +34,12 @@ def triangulate(i0,i1,i2):
         k=k+3
     for i in range(len(lons)):
         lons[i] = shiftarg_lon(lons[i])
-        print('triangulating done.')      
+        # print('triangulating done.')      
     return lons,lats,intmat
 
 def triangulate1(lats,lons):
     "Prepare data for tri.Triangulate."
-    print('triangulating1...')
+    # print('triangulating1...')
     intmat=[]
     npts=int(len(lats)/3)
     k=0
@@ -48,7 +48,7 @@ def triangulate1(lats,lons):
         k=k+3
     for i in range(len(lons)):
         lons[i] = shiftarg_lon(lons[i])
-    print('triangulating1 done.')      
+    # print('triangulating1 done.')      
     return lons,lats,intmat
 
 
@@ -122,13 +122,13 @@ class MainTest(unittest.TestCase):
         lat0 = numpy.array([ 10, 5, 60,70], dtype=numpy.double)
         lon0 = numpy.array([-30,-20,60,10], dtype=numpy.double)
         hull0 = pystare.to_hull_range_from_latlon(lat0, lon0, resolution0)
-        print("len hull0: ",len(hull0))
+        # print("len hull0: ",len(hull0))
                                               
         resolution1 = 6
         lat1 = numpy.array([10,  20, 30, 20 ], dtype=numpy.double)
         lon1 = numpy.array([-60, 60, 60, -60], dtype=numpy.double)
         hull1 = pystare.to_hull_range_from_latlon(lat1, lon1, resolution1)
-        print("len hull1: ",len(hull1))
+        # print("len hull1: ",len(hull1))
 
         r0 = pystare.srange()
         r0.add_intervals(hull0)
@@ -137,15 +137,15 @@ class MainTest(unittest.TestCase):
         r1.add_intervals(hull1)
 
         r01 = pystare.srange()
-        print("0800")
+        # print("0800")
         
         r01.add_intersect(r0,r1,False)
         r01.set_values_multi_resolution(False)
-        print("0900")
+        # print("0900")
         
         n01 = r01.get_size_as_values()
 
-        print("1000")
+        # print("1000")
         self.assertEqual(328, n01)
         intersected = numpy.zeros([n01],dtype=numpy.int64)
         r01.copy_values(intersected)
@@ -192,7 +192,7 @@ class MainTest(unittest.TestCase):
         r0.acontains(intersected,intersected1,-1) # An element in r01 should be in r0, yes?
         for i in range(len(intersected)):
             # print(i,'i',hex(intersected[i]),hex(intersected1[i]))
-            print('%3d = i, %016x, %016x, %016x'%(i,intersected[i],intersected1[i],intersected0[i]))
+            # print('%3d = i, %016x, %016x, %016x'%(i,intersected[i],intersected1[i],intersected0[i]))
             if i % 2 == 0:
                 self.assertEqual(-1,intersected1[i])
             else:

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -52,21 +52,44 @@ class MainTest(unittest.TestCase):
         numpy.testing.assert_allclose(area, expected)
     
     def test__tocompressedrange(self):
-        indices = numpy.array([4151504989081014892, 4161865161846704588, 3643626718498217164])
+        
+        # indices = numpy.array([4151504989081014892, 4161865161846704588, 3643626718498217164])
+        # expected = numpy.array([3643626718498217164, 4151504989081014892, 4161865161846704588])
+
+        indices  = numpy.array([0x399d1bcabd6f926c,0x39c1ea506ef249cc,0x3290c3321a355ccc])
+        expected = numpy.array([0x3290c3300000000c,0x399d1bc80000000c,0x39c1ea500000000c])
+
         compressed = numpy.array([0, 0, 0], dtype=numpy.int64)
         pystare._to_compressed_range(indices, compressed)
-        expected = numpy.array([3643626718498217164, 4151504989081014892, 4161865161846704588])
+            
         numpy.testing.assert_array_equal(compressed, expected)
     
     def test_tocompressedrange(self):
-        indices = numpy.array([4151504989081014892, 4161865161846704588, 3643626718498217164])
+
+        # indices = numpy.array([4151504989081014892, 4161865161846704588, 3643626718498217164])
+        # expected = numpy.array([3643626718498217164, 4151504989081014892, 4161865161846704588])
+
+        indices  = numpy.array([0x399d1bcabd6f926c,0x39c1ea506ef249cc,0x3290c3321a355ccc])
+        expected = numpy.array([0x3290c3300000000c,0x399d1bc80000000c,0x39c1ea500000000c])
+        
         compressed = pystare.to_compressed_range(indices)
-        expected = numpy.array([3643626718498217164, 4151504989081014892, 4161865161846704588])
+
+        # print('')
+        # print('indices','compressed','expected')
+        # for i in [0,1,2]:
+        #     print(i,hex(indices[i]),hex(compressed[i]),hex(expected[i]))
+        # print('\nindices')
+        # for i in [0,1,2]:
+        #     print(hex(indices[i]))
+        # print('\ncompressed')
+        # for i in [0,1,2]:
+        #     print(hex(compressed[i]))
+        
         numpy.testing.assert_array_equal(compressed, expected)
 
     def test__tohullrange(self):
         indices = numpy.array([4151504989081014892, 4161865161846704588, 3643626718498217164])
-        result_size = numpy.zeros([1], dtype=numpy.int)
+        result_size = numpy.zeros([1], dtype=numpy.int64)
         result = pystare._to_hull_range(indices, 8)
         hull_indices = numpy.zeros([result.get_size_as_intervals()], dtype=numpy.int64)
         result.copy_as_intervals(hull_indices)

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -124,7 +124,7 @@ class MainTest(unittest.TestCase):
         expanded_len       = numpy.zeros([1],dtype=numpy.int64)
         intervals_len = len(src)
         resolution = -1
-        result = pystare._expand_intervals(src, resolution)
+        result = pystare._expand_intervals(src, resolution, multi_resolution=False)
         expanded_len = result.get_size_as_values()
         result.copy_as_values(expanded)
         self.assertEqual(expanded_len, 74)
@@ -139,7 +139,7 @@ class MainTest(unittest.TestCase):
         src = numpy.array(intervals.src,dtype=numpy.int64)
         expected_expanded = numpy.array(intervals.expanded_src,dtype=numpy.int64)
         resolution = -1
-        expanded = pystare.expand_intervals(src, resolution)        
+        expanded = pystare.expand_intervals(src, resolution, multi_resolution=False)        
         error_found = False
         for i in range(len(expanded)):
             if(expanded[i] != expected_expanded[i]):

--- a/tests/test_srange.py
+++ b/tests/test_srange.py
@@ -12,7 +12,7 @@ class MainTest(unittest.TestCase):
         
     def test_make_srange10000(self):
         from tests.sids import sids
-        sids = sids[0:1000]
+        sids = sids[0:10000]
         srange = pystare.srange(sids)
         
     def test_collapse1(self):

--- a/tests/test_srange.py
+++ b/tests/test_srange.py
@@ -2,15 +2,16 @@ import numpy
 import pystare 
 import unittest
 
-from sids import sids
 
 class MainTest(unittest.TestCase):
     
     def test_make_srange1000(self):
+        from tests.sids import sids
         sids = sids[0:1000]
         srange = pystare.srange(sids)
         
-    def test_make_srange10000(self)
+    def test_make_srange10000(self):
+        from tests.sids import sids
         sids = sids[0:1000]
         srange = pystare.srange(sids)
         
@@ -22,6 +23,23 @@ class MainTest(unittest.TestCase):
                             0x300a31000000000a,
                             0x300a31800000000a])
         ivs = pystare.to_compressed_range(sids.flatten())
-        indices = numpy.zeros([srange.get_size_as_values()], dtype=numpy.int64)
-        srange.copy_values(indices)
-        self.assertEqual()
+        #indices = numpy.zeros([srange.get_size_as_values()], dtype=numpy.int64)
+        #srange.copy_values(indices)
+        with self.subTest():
+            self.assertEqual(ivs.size, 1)
+        with self.subTest():    
+            self.assertEqual(hex(ivs[0]), '0x300a300000000009')
+        
+    def test_collapse2(self):
+        # parent with same ancestor
+        sids = numpy.array([0x300a30000000000a,
+                            0x300a30800000000a,
+                            0x300a31000000000a,
+                            0x300a31800000000a])
+        ivs = pystare.to_compressed_range(sids.flatten())
+        #indices = numpy.zeros([srange.get_size_as_values()], dtype=numpy.int64)
+        #srange.copy_values(indices)
+        with self.subTest():
+            self.assertEqual(ivs.size, 1)
+        with self.subTest():    
+            self.assertEqual(hex(ivs[0]), '0x300a300000000009')

--- a/tests/test_srange.py
+++ b/tests/test_srange.py
@@ -51,6 +51,7 @@ class MainTest(unittest.TestCase):
                              0x3000000000000000, 0x3800000000000000])
         sids = numpy.array([0x300a30000000000a, 0x300a30800000000a, 0x300a31000000000a, 0x300a31800000000a])
         indices = pystare.intersect(earth, sids, multiresolution=True)
+        ivs = indices
         with self.subTest():
             self.assertEqual(ivs.size, 1)
         with self.subTest():    
@@ -60,6 +61,7 @@ class MainTest(unittest.TestCase):
         sids = numpy.array([0x300a30000000000a, 0x300a30800000000a, 0x300a31000000000a, 0x300a31800000000a])
         parent = pystare.expand_intervals(sids, resolution=9)
         indices = pystare.intersect(parent, sids)
+        ivs = indices
         with self.subTest():
             self.assertEqual(ivs.size, 1)
         with self.subTest():    

--- a/tests/test_srange.py
+++ b/tests/test_srange.py
@@ -1,0 +1,27 @@
+import numpy 
+import pystare 
+import unittest
+
+from sids import sids
+
+class MainTest(unittest.TestCase):
+    
+    def test_make_srange1000(self):
+        sids = sids[0:1000]
+        srange = pystare.srange(sids)
+        
+    def test_make_srange10000(self)
+        sids = sids[0:1000]
+        srange = pystare.srange(sids)
+        
+    def test_collapse1(self):
+        # parent with 4 children 
+        sids = numpy.array([0x300a300000000009,
+                            0x300a30000000000a,
+                            0x300a30800000000a,
+                            0x300a31000000000a,
+                            0x300a31800000000a])
+        ivs = pystare.to_compressed_range(sids.flatten())
+        indices = numpy.zeros([srange.get_size_as_values()], dtype=numpy.int64)
+        srange.copy_values(indices)
+        self.assertEqual()

--- a/tests/test_srange.py
+++ b/tests/test_srange.py
@@ -43,3 +43,25 @@ class MainTest(unittest.TestCase):
             self.assertEqual(ivs.size, 1)
         with self.subTest():    
             self.assertEqual(hex(ivs[0]), '0x300a300000000009')
+            
+    def test_multires_intersect1(self):
+        # Earth are the 8 initial trixels
+        earth = numpy.array([0x0000000000000000, 0x0800000000000000, 0x1000000000000000, 
+                             0x1800000000000000, 0x2000000000000000, 0x2800000000000000,
+                             0x3000000000000000, 0x3800000000000000])
+        sids = numpy.array([0x300a30000000000a, 0x300a30800000000a, 0x300a31000000000a, 0x300a31800000000a])
+        indices = pystare.intersect(earth, sids, multiresolution=True)
+        with self.subTest():
+            self.assertEqual(ivs.size, 1)
+        with self.subTest():    
+            self.assertEqual(hex(ivs[0]), '0x300a300000000009')
+            
+    def test_multires_intersect2(self):
+        sids = numpy.array([0x300a30000000000a, 0x300a30800000000a, 0x300a31000000000a, 0x300a31800000000a])
+        parent = pystare.expand_intervals(sids, resolution=9)
+        indices = pystare.intersect(parent, sids)
+        with self.subTest():
+            self.assertEqual(ivs.size, 1)
+        with self.subTest():    
+            self.assertEqual(hex(ivs[0]), '0x300a300000000009')
+        


### PR DESCRIPTION
srange and intersect were often not returning multi-resolution
results. Added a set_values_multi_resolution method to srange and
added a multi_resolution flag to StareResult. Setting values
multi_resolution to true turns on expandIntervalsMultiRes, coalescing
quadruplets of trixels whenever it can. If values multi_resolution is
false then we should get expansions based on the resolution encoded
with the interval.