### PR TITLE
feat: upgrade to Python 3.12 and Numpy to 2.2.1. Update pystare temporal examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ datetime = numpy.array(['1970-01-01T00:00:00',
 print(datetime)
 print(datetime.astype(numpy.int64))
     
-index = pystare.from_utc(datetime.astype(numpy.int64), 6)
+index = pystare.from_ms_since_epoch_utc(datetime.astype(numpy.int64), 6, 6)
 print([hex(i) for i in index])
 
-index = pystare.from_utc(datetime.astype(numpy.int64), 27)
+index = pystare.from_ms_since_epoch_utc(datetime.astype(numpy.int64), 27, 27)
 print([hex(i) for i in index])
 
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,9 @@ classifiers =
 [options]
 package_dir =
 packages = pystare
-python_requires= >=3.7
-install_requires = numpy>=1.21.6
-setup_requires = numpy>=1.21.6
+python_requires= >=3.12
+install_requires = numpy>=2.2.1
+setup_requires = numpy>=2.2.1
 include_package_data = False
     
 


### PR DESCRIPTION
Upgrade:
- Python 3.12
- Numpy 2.2.1
Update:
- README.md